### PR TITLE
Save edited HTML on configuration changed

### DIFF
--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -41,6 +41,8 @@ class EditorReloader(private val coroutineScope: CoroutineScope) {
      *     }
      * }
      * ```
+     *
+     * @throws IllegalStateException If the method is not called on the main thread.
      */
     suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
         if (Looper.myLooper() != Looper.getMainLooper()) error("The load method needs to be called on the main thread")

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -1,5 +1,6 @@
 package com.infomaniak.lib.richhtmleditor
 
+import android.os.Looper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -42,6 +43,8 @@ class EditorReloader(private val coroutineScope: CoroutineScope) {
      * ```
      */
     suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
+        if (Looper.myLooper() != Looper.getMainLooper()) throw error("The load method needs to be called on the main thread")
+
         if (needToReloadHtml) {
             savedHtml.collectLatest {
                 if (it == null) return@collectLatest

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -2,17 +2,18 @@ package com.infomaniak.lib.richhtmleditor
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class EditorReloader(private val viewModelScope: CoroutineScope) {
+class EditorReloader(private val coroutineScope: CoroutineScope) {
 
     private var needToReloadHtml: Boolean = false
     private var savedHtml = MutableStateFlow<String?>(null)
 
     suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
         if (needToReloadHtml) {
-            savedHtml.collect {
-                if (it == null) return@collect
+            savedHtml.collectLatest {
+                if (it == null) return@collectLatest
 
                 resetSavedHtml()
                 editor.setHtml(it)
@@ -26,7 +27,7 @@ class EditorReloader(private val viewModelScope: CoroutineScope) {
 
     fun save(editor: RichHtmlEditorWebView) {
         editor.exportHtml {
-            viewModelScope.launch { savedHtml.emit(it) }
+            coroutineScope.launch { savedHtml.emit(it) }
         }
     }
 

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -5,11 +5,42 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+/**
+ * A utility class to help easily reload the html content of a [RichHtmlEditorWebView] on configuration changes.
+ *
+ * This class is meant to be instantiated inside a ViewModel to be able to retain the HTML content through configuration changes.
+ *
+ * @param coroutineScope A coroutine scope where the exportation of the HTML will be processed. Preferably the viewModelScope of
+ * the ViewModel where this class has been instantiated.
+ *
+ * @see load
+ * @see save
+ */
 class EditorReloader(private val coroutineScope: CoroutineScope) {
 
     private var needToReloadHtml: Boolean = false
     private var savedHtml = MutableStateFlow<String?>(null)
 
+    /**
+     * An alternative for loading the HTML content of the [RichHtmlEditorWebView].
+     *
+     * This method can be called within the `onViewCreated()` method of the Fragment containing your [RichHtmlEditorWebView].
+     * On the initial call, it loads the default HTML content. For all subsequent calls, it reloads the previously loaded HTML
+     * content.
+     *
+     * @param editor The editor to load content into.
+     * @param defaultHtml The HTML to load on the initial call. On subsequent calls, this value won't be taken into account.
+     *
+     * Usage:
+     * ```
+     * override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+     *     super.onViewCreated(view, savedInstanceState)
+     *     lifecycleScope.launch {
+     *         viewModel.editorReloader.load(editor, "<p>Hello World</p>")
+     *     }
+     * }
+     * ```
+     */
     suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
         if (needToReloadHtml) {
             savedHtml.collectLatest {
@@ -25,6 +56,21 @@ class EditorReloader(private val coroutineScope: CoroutineScope) {
         enableHtmlReload()
     }
 
+    /**
+     * Exports and saves the editor's HTML content for later reloading.
+     *
+     * This method should be called within the `onSaveInstanceState()` method of the Fragment.
+     *
+     * @param editor The editor whose content needs to be saved.
+     *
+     * Usage:
+     * ```
+     * override fun onSaveInstanceState(outState: Bundle) {
+     *     super.onSaveInstanceState(outState)
+     *     viewModel.editorReloader.save(editor)
+     * }
+     * ```
+     */
     fun save(editor: RichHtmlEditorWebView) {
         editor.exportHtml {
             coroutineScope.launch { savedHtml.emit(it) }

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -1,0 +1,40 @@
+package com.infomaniak.lib.richhtmleditor
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+class EditorReloader(private val viewModelScope: CoroutineScope) {
+
+    private var needToReloadHtml: Boolean = false
+    private var savedHtml = MutableStateFlow<String?>(null)
+
+    suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
+        if (needToReloadHtml) {
+            savedHtml.collect {
+                if (it == null) return@collect
+
+                resetSavedHtml()
+                editor.setHtml(it)
+            }
+        } else {
+            editor.setHtml(defaultHtml)
+        }
+
+        enableHtmlReload()
+    }
+
+    fun save(editor: RichHtmlEditorWebView) {
+        editor.exportHtml {
+            viewModelScope.launch { savedHtml.emit(it) }
+        }
+    }
+
+    private suspend fun resetSavedHtml() {
+        savedHtml.emit(null)
+    }
+
+    private fun enableHtmlReload() {
+        needToReloadHtml = true
+    }
+}

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/EditorReloader.kt
@@ -43,7 +43,7 @@ class EditorReloader(private val coroutineScope: CoroutineScope) {
      * ```
      */
     suspend fun load(editor: RichHtmlEditorWebView, defaultHtml: String) {
-        if (Looper.myLooper() != Looper.getMainLooper()) throw error("The load method needs to be called on the main thread")
+        if (Looper.myLooper() != Looper.getMainLooper()) error("The load method needs to be called on the main thread")
 
         if (needToReloadHtml) {
             savedHtml.collectLatest {

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
@@ -34,9 +34,9 @@ class EditorSampleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
         super.onViewCreated(view, savedInstanceState)
 
-        setEditorHtml()
-
         setToolbarEnabledStatus(false)
+
+        setEditorContent()
         editor.apply {
             // You can add custom scripts and css such as:
             // addCss(readAsset("editor_custom_css.css"))
@@ -50,20 +50,10 @@ class EditorSampleFragment : Fragment() {
         observeEditorStatusUpdates()
     }
 
-    private fun setEditorHtml() = with(binding) {
-        if (editorSampleViewModel.needToReloadHtml) {
-            lifecycleScope.launch {
-                editorSampleViewModel.savedHtml.collect {
-                    if (it == null) return@collect
-
-                    editorSampleViewModel.resetSavedHtml()
-                    editor.setHtml(it)
-                }
-            }
-        } else {
-            editor.setHtml(readAsset("example1.html"))
+    private fun setEditorContent() {
+        lifecycleScope.launch {
+            editorSampleViewModel.editorReloader.load(binding.editor, readAsset("example1.html"))
         }
-        editorSampleViewModel.enableHtmlReload()
     }
 
     private fun setEditorButtonClickListeners() = with(binding) {
@@ -106,9 +96,7 @@ class EditorSampleFragment : Fragment() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        binding.editor.exportHtml {
-            editorSampleViewModel.saveHtml(it)
-        }
+        editorSampleViewModel.editorReloader.save(binding.editor)
         super.onSaveInstanceState(outState)
     }
 

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
@@ -10,6 +10,7 @@ import android.view.inputmethod.InputMethodManager
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.infomaniak.lib.richhtmleditor.sample.databinding.CreateLinkTextInputBinding
@@ -22,6 +23,8 @@ class EditorSampleFragment : Fragment() {
     private var _binding: FragmentEditorSampleBinding? = null
     private val binding get() = _binding!! // This property is only valid between onCreateView and onDestroyView
 
+    private val editorSampleViewModel: EditorSampleViewModel by activityViewModels()
+
     private val createLinkDialog by lazy { CreateLinkDialog() }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -31,7 +34,7 @@ class EditorSampleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
         super.onViewCreated(view, savedInstanceState)
 
-        val html = readAsset("example1.html")
+        setEditorHtml()
 
         setToolbarEnabledStatus(false)
         editor.apply {
@@ -39,15 +42,28 @@ class EditorSampleFragment : Fragment() {
             // addCss(readAsset("editor_custom_css.css"))
             // addScript("document.body.style['background'] = '#00FFFF'")
 
-            setHtml(html)
-
             isVisible = true
-
             setOnFocusChangeListener { _, hasFocus -> setToolbarEnabledStatus(hasFocus) }
         }
 
         setEditorButtonClickListeners()
         observeEditorStatusUpdates()
+    }
+
+    private fun setEditorHtml() = with(binding) {
+        if (editorSampleViewModel.needToReloadHtml) {
+            lifecycleScope.launch {
+                editorSampleViewModel.savedHtml.collect {
+                    if (it == null) return@collect
+
+                    editorSampleViewModel.resetSavedHtml()
+                    editor.setHtml(it)
+                }
+            }
+        } else {
+            editor.setHtml(readAsset("example1.html"))
+        }
+        editorSampleViewModel.enableHtmlReload()
     }
 
     private fun setEditorButtonClickListeners() = with(binding) {
@@ -87,6 +103,13 @@ class EditorSampleFragment : Fragment() {
                 buttonLink.isActivated = it.isLinkSelected
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        binding.editor.exportHtml {
+            editorSampleViewModel.saveHtml(it)
+        }
+        super.onSaveInstanceState(outState)
     }
 
     override fun onDestroyView() {

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleViewModel.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleViewModel.kt
@@ -1,0 +1,28 @@
+package com.infomaniak.lib.richhtmleditor.sample
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class EditorSampleViewModel : ViewModel() {
+    var needToReloadHtml: Boolean = false
+        private set
+    private var _savedHtml = MutableStateFlow<String?>(null)
+    val savedHtml: StateFlow<String?> = _savedHtml
+
+    fun saveHtml(html: String) {
+        viewModelScope.launch { _savedHtml.emit(html) }
+    }
+
+    fun enableHtmlReload() {
+        needToReloadHtml = true
+    }
+
+    fun resetSavedHtml() {
+        viewModelScope.launch {
+            _savedHtml.emit(null)
+        }
+    }
+}

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleViewModel.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleViewModel.kt
@@ -2,27 +2,8 @@ package com.infomaniak.lib.richhtmleditor.sample
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
+import com.infomaniak.lib.richhtmleditor.EditorReloader
 
 class EditorSampleViewModel : ViewModel() {
-    var needToReloadHtml: Boolean = false
-        private set
-    private var _savedHtml = MutableStateFlow<String?>(null)
-    val savedHtml: StateFlow<String?> = _savedHtml
-
-    fun saveHtml(html: String) {
-        viewModelScope.launch { _savedHtml.emit(html) }
-    }
-
-    fun enableHtmlReload() {
-        needToReloadHtml = true
-    }
-
-    fun resetSavedHtml() {
-        viewModelScope.launch {
-            _savedHtml.emit(null)
-        }
-    }
+    val editorReloader = EditorReloader(viewModelScope)
 }


### PR DESCRIPTION
When the html is edited by the user, we need to keep the changes and reload the edited html across config changes

Depends on #14 