### PR TITLE
Split old setHtml method into independent basic logic components

### DIFF
--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/DocumentInitializer.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/DocumentInitializer.kt
@@ -20,55 +20,7 @@ package com.infomaniak.lib.richhtmleditor
 import android.webkit.WebView
 
 internal class DocumentInitializer {
-
-    private var html: String? = null
-    private var subscribedStates: Set<StatusCommand>? = null
-
-    fun init(html: String, subscribedStates: Set<StatusCommand>?) {
-        this.html = html
-        this.subscribedStates = subscribedStates
-    }
-
     fun setupDocument(webView: WebView) = with(webView) {
-        insertUserHtml()
-
-        injectScript(createSubscribedStatesScript())
         injectScript(context.readAsset("attach_listeners.js")) // Needs to only be called once the page has finished loading
-    }
-
-    private fun WebView.insertUserHtml() {
-        evaluateJavascript("""document.getElementById("$EDITOR_ID").innerHTML = `${html}`""", null)
-    }
-
-    private fun createSubscribedStatesScript(): String {
-        val subscribedStates = subscribedStates ?: StatusCommand.entries
-
-        val stateCommands = mutableListOf<StatusCommand>()
-        val valueCommands = mutableListOf<StatusCommand>()
-
-        subscribedStates.forEach {
-            when (it.statusType) {
-                StatusType.STATE -> stateCommands.add(it)
-                StatusType.VALUE -> valueCommands.add(it)
-                StatusType.COMPLEX -> Unit
-            }
-        }
-
-        val firstLine = generateConstTable("stateCommands", stateCommands)
-        val secondLine = generateConstTable("valueCommands", valueCommands)
-
-        val areLinksSubscribedTo = subscribedStates.contains(StatusCommand.CREATE_LINK)
-        val reportLinkStatusLine = "const REPORT_LINK_STATUS = $areLinksSubscribedTo"
-
-        return "$firstLine\n$secondLine\n$reportLinkStatusLine"
-    }
-
-    private fun generateConstTable(name: String, commands: Collection<StatusCommand>): String {
-        return commands.joinToString(prefix = "const $name = [ ", postfix = " ]") { "'${it.argumentName}'" }
-    }
-
-    companion object {
-        // The id of this HTML tag is shared across multiple files and needs to remain the same
-        private const val EDITOR_ID = "editor"
     }
 }

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Extensions.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Extensions.kt
@@ -31,16 +31,27 @@ internal fun Context.readAsset(fileName: String): String {
         .use(BufferedReader::readText)
 }
 
-internal fun WebView.injectScript(scriptCode: String) {
+internal fun WebView.injectScript(scriptCode: String, id: String? = null) {
+    val removePreviousId = id?.let {
+        """
+        var previousScript = document.getElementById(`$it`)
+        if (previousScript) previousScript.remove()
+        """.trimIndent()
+    } ?: ""
+
+    val setId = id?.let { "script.id = `${it}`;" } ?: ""
     val addScriptJs = """
         var script = document.createElement('script');
         script.type = 'text/javascript';
         script.text = `${scriptCode}`;
+        $setId
 
         document.head.appendChild(script);
         """.trimIndent()
 
-    evaluateJavascript(addScriptJs, null)
+    val code = removePreviousId + "\n" + addScriptJs
+
+    evaluateJavascript(code, null)
 }
 
 internal fun WebView.injectCss(css: String) {

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
@@ -109,6 +109,7 @@ class RichHtmlEditorWebView @JvmOverloads constructor(
 
         addJavascriptInterface(jsBridge, "editor")
 
+        stateSubscriber.executeWhenDomIsLoaded(null)
         val template = context.readAsset("editor_template.html")
         super.loadDataWithBaseURL("", template, "text/html", "UTF-8", null)
 

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/HtmlSetter.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/HtmlSetter.kt
@@ -17,20 +17,18 @@
  */
 package com.infomaniak.lib.richhtmleditor.executor
 
-internal abstract class JsLifecycleAwareExecutor<T> {
+import android.webkit.WebView
 
-    private var hasDomLoaded = false
-    private val objectsWaitingForDom = mutableListOf<T>()
+internal class HtmlSetter(private val webView: WebView) : JsLifecycleAwareExecutor<String>() {
 
-    fun executeWhenDomIsLoaded(value: T): Unit = synchronized(lock = this) {
-        if (hasDomLoaded) executeImmediately(value) else objectsWaitingForDom.add(value)
+    override fun executeImmediately(value: String) = webView.insertUserHtml(value)
+
+    private fun WebView.insertUserHtml(html: String) {
+        evaluateJavascript("""document.getElementById("$EDITOR_ID").innerHTML = `${html}`""", null)
     }
 
-    fun notifyDomLoaded() = synchronized(lock = this) {
-        hasDomLoaded = true
-        objectsWaitingForDom.forEach(::executeImmediately)
-        objectsWaitingForDom.clear()
+    companion object {
+        // The id of this HTML tag is shared across multiple files and needs to remain the same
+        private const val EDITOR_ID = "editor"
     }
-
-    abstract fun executeImmediately(value: T)
 }

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/StateSubscriber.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/StateSubscriber.kt
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak Rich HTML Editor - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.lib.richhtmleditor.executor
+
+import android.webkit.WebView
+import com.infomaniak.lib.richhtmleditor.StatusCommand
+import com.infomaniak.lib.richhtmleditor.StatusType
+import com.infomaniak.lib.richhtmleditor.injectScript
+
+internal class StateSubscriber(private val webView: WebView) : JsLifecycleAwareExecutor<Set<StatusCommand>?>() {
+
+    override fun executeImmediately(value: Set<StatusCommand>?) {
+        webView.injectScript(createSubscribedStatesScript(value), "subscribedStates")
+    }
+
+    private fun createSubscribedStatesScript(inputSubscribedStates: Set<StatusCommand>?): String {
+        val subscribedStates = inputSubscribedStates ?: StatusCommand.entries
+
+        val stateCommands = mutableListOf<StatusCommand>()
+        val valueCommands = mutableListOf<StatusCommand>()
+
+        subscribedStates.forEach {
+            when (it.statusType) {
+                StatusType.STATE -> stateCommands.add(it)
+                StatusType.VALUE -> valueCommands.add(it)
+                StatusType.COMPLEX -> Unit
+            }
+        }
+
+        val firstLine = generateConstTable("stateCommands", stateCommands)
+        val secondLine = generateConstTable("valueCommands", valueCommands)
+
+        val areLinksSubscribedTo = subscribedStates.contains(StatusCommand.CREATE_LINK)
+        val reportLinkStatusLine = "var REPORT_LINK_STATUS = $areLinksSubscribedTo"
+
+        return "$firstLine\n$secondLine\n$reportLinkStatusLine"
+    }
+
+    private fun generateConstTable(name: String, commands: Collection<StatusCommand>): String {
+        return commands.joinToString(prefix = "var $name = [ ", postfix = " ]") { "'${it.argumentName}'" }
+    }
+}

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.infomaniak.lib.richhtmleditor.Justification
+import com.infomaniak.lib.richhtmleditor.StatusCommand
 import com.infomaniak.lib.richhtmleditor.sample.databinding.CreateLinkTextInputBinding
 import com.infomaniak.lib.richhtmleditor.sample.databinding.FragmentEditorSampleBinding
 import kotlinx.coroutines.launch
@@ -57,9 +58,10 @@ class EditorSampleFragment : Fragment() {
 
         setEditorContent()
         editor.apply {
-            // You can add custom scripts and css such as:
+            // You can configure the editor as follows:
             // addCss(readAsset("editor_custom_css.css"))
             // addScript("document.body.style['background'] = '#00FFFF'")
+            // subscribeToStates(setOf(StatusCommand.BOLD, StatusCommand.ITALIC))
 
             isVisible = true
             setOnFocusChangeListener { _, hasFocus -> setToolbarEnabledStatus(hasFocus) }

--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
@@ -32,7 +32,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.infomaniak.lib.richhtmleditor.Justification
-import com.infomaniak.lib.richhtmleditor.StatusCommand
 import com.infomaniak.lib.richhtmleditor.sample.databinding.CreateLinkTextInputBinding
 import com.infomaniak.lib.richhtmleditor.sample.databinding.FragmentEditorSampleBinding
 import kotlinx.coroutines.launch
@@ -58,7 +57,7 @@ class EditorSampleFragment : Fragment() {
 
         setEditorContent()
         editor.apply {
-            // You can configure the editor as follows:
+            // You can configure the editor like this:
             // addCss(readAsset("editor_custom_css.css"))
             // addScript("document.body.style['background'] = '#00FFFF'")
             // subscribeToStates(setOf(StatusCommand.BOLD, StatusCommand.ITALIC))


### PR DESCRIPTION
`setHtml` was doing too many things and did not give enough freedom and control over the editor. All of what this method used to do has been split into independently callable methods.

Now the content of the editor can be set by itself, the states can be subscribed to by themselves and the initial loading of the editor's HTML template is done as soon as possible

Depends on #20 