### PR TITLE
Remove unnecessary argumentName value and add clarifying comment

### DIFF
--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/StatusCommand.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/StatusCommand.kt
@@ -34,7 +34,7 @@ enum class StatusCommand(override val argumentName: String, val statusType: Stat
     FONT_SIZE("fontSize", StatusType.VALUE),
     TEXT_COLOR("foreColor", StatusType.VALUE),
     BACKGROUND_COLOR("backColor", StatusType.VALUE),
-    CREATE_LINK("createLink", StatusType.COMPLEX),
+    CREATE_LINK("", StatusType.COMPLEX), // This value is not meant to be called by JsBride's execCommand()
 }
 
 enum class OtherCommand(override val argumentName: String) : ExecCommand {


### PR DESCRIPTION
StatusCommand.CREATE_LINK is only in StatusCommand because it returns a status and can be subscribed to but it cannot be called through execCommand directly

Depends on #20 