### PR TITLE
Move saving of the html where it actually matters

### DIFF
--- a/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
+++ b/sample/src/main/java/com/infomaniak/lib/richhtmleditor/sample/EditorSampleFragment.kt
@@ -146,12 +146,8 @@ class EditorSampleFragment : Fragment() {
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        editorSampleViewModel.editorReloader.save(binding.editor)
-        super.onSaveInstanceState(outState)
-    }
-
     override fun onDestroyView() {
+        editorSampleViewModel.editorReloader.save(binding.editor)
         super.onDestroyView()
         _binding = null
     }


### PR DESCRIPTION
onSaveInstanceState is cool for when you want to survive process being killed but onDestroyView is enough to survive configuration changes

Depends on #24 