### PR TITLE
Fix content twitching when resizing webview

### DIFF
--- a/rich-html-editor/src/main/assets/editor_template.html
+++ b/rich-html-editor/src/main/assets/editor_template.html
@@ -26,7 +26,5 @@
 <body style="height: fit-content;">
 <!-- The id of this HTML tag is shared across multiple files and needs to remain the same -->
 <section contenteditable="true" id="editor" style="outline: none"></section>
-<!-- Used to prevent new lines on the very last line from making the webview twitch -->
-<div style="height: 1rem"></div>
 </body>
 </html>

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
@@ -272,6 +272,9 @@ class RichHtmlEditorWebView @JvmOverloads constructor(
         }
     }
 
+    // Prevent scrolling bug that makes the editor twitch
+    override fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean) = Unit
+
     @Deprecated(
         "Use setHtml() instead to initialize the editor with the desired HTML content.",
         ReplaceWith("setHtml()", "com.infomaniak.lib.richhtmleditor")


### PR DESCRIPTION
If we spam really hard new lines on the last line of the editor for a long time, sometimes it still occurs but does not trigger any scroll listener anymore. The same behavior got observed in gmail and is deemed rare enough