### PR TITLE
Set min editor height

### DIFF
--- a/rich-html-editor/src/main/assets/editor_template.html
+++ b/rich-html-editor/src/main/assets/editor_template.html
@@ -25,6 +25,6 @@
 </head>
 <body style="height: fit-content;">
 <!-- The id of this HTML tag is shared across multiple files and needs to remain the same -->
-<section contenteditable="true" id="editor" style="outline: none; min-height: 1rem;"></section>
+<div contenteditable="true" id="editor" style="outline: none; min-height: 1rem;"></div>
 </body>
 </html>

--- a/rich-html-editor/src/main/assets/editor_template.html
+++ b/rich-html-editor/src/main/assets/editor_template.html
@@ -25,6 +25,6 @@
 </head>
 <body style="height: fit-content;">
 <!-- The id of this HTML tag is shared across multiple files and needs to remain the same -->
-<section contenteditable="true" id="editor" style="outline: none"></section>
+<section contenteditable="true" id="editor" style="outline: none; min-height: 1rem;"></section>
 </body>
 </html>


### PR DESCRIPTION
If the editor only contains tags with not texts, it can become 0px high which renders it unclickable. This sets the min height to one ligne so there's always somewhere to click to take the focus. Also use this opportunity to change the section into a div to stay coherent with iOS and because a section is not required here

Depends on #26 