### PR TITLE
Make sure inserted content inside JS is properly escaped

### DIFF
--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Utils.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Utils.kt
@@ -31,7 +31,5 @@ fun looselyEscapeAsStringLiteralForJs(string: String): String {
         stringBuilder.append(char)
     }
 
-    stringBuilder.append("`")
-
-    return stringBuilder.toString()
+    return stringBuilder.append("`").toString()
 }

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Utils.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/Utils.kt
@@ -1,0 +1,37 @@
+/*
+ * Infomaniak Rich HTML Editor - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.lib.richhtmleditor
+
+// TODO: This method might not be enough to escape user inputs and prevent access to JS code execution
+fun looselyEscapeAsStringLiteralForJs(string: String): String {
+    val stringBuilder = StringBuilder("`")
+
+    string.forEach {
+        val char = when (it) {
+            '`' -> "\\`"
+            '\\' -> "\\\\"
+            '$' -> "\\$"
+            else -> it
+        }
+        stringBuilder.append(char)
+    }
+
+    stringBuilder.append("`")
+
+    return stringBuilder.toString()
+}

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/HtmlSetter.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/HtmlSetter.kt
@@ -18,13 +18,15 @@
 package com.infomaniak.lib.richhtmleditor.executor
 
 import android.webkit.WebView
+import com.infomaniak.lib.richhtmleditor.looselyEscapeAsStringLiteralForJs
 
 internal class HtmlSetter(private val webView: WebView) : JsLifecycleAwareExecutor<String>() {
 
     override fun executeImmediately(value: String) = webView.insertUserHtml(value)
 
     private fun WebView.insertUserHtml(html: String) {
-        evaluateJavascript("""document.getElementById("$EDITOR_ID").innerHTML = `${html}`""", null)
+        val escapedHtmlStringLiteral = looselyEscapeAsStringLiteralForJs(html)
+        evaluateJavascript("""document.getElementById("$EDITOR_ID").innerHTML = $escapedHtmlStringLiteral""", null)
     }
 
     companion object {

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsExecutableMethod.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsExecutableMethod.kt
@@ -20,6 +20,7 @@ package com.infomaniak.lib.richhtmleditor.executor
 import android.webkit.WebView
 import androidx.annotation.ColorInt
 import com.infomaniak.lib.richhtmleditor.JsColor
+import com.infomaniak.lib.richhtmleditor.looselyEscapeAsStringLiteralForJs
 
 class JsExecutableMethod(
     private val methodName: String,
@@ -56,25 +57,6 @@ class JsExecutableMethod(
                 is JsColor -> "'${colorToRgbHex(value.color)}'"
                 else -> throw NotImplementedError("Encoding ${value::class} for JS is not yet implemented")
             }
-        }
-
-        // TODO: This method might not be enough to escape user inputs and prevent access to JS code execution
-        private fun looselyEscapeAsStringLiteralForJs(string: String): String {
-            val stringBuilder = StringBuilder("`")
-
-            string.forEach {
-                val char = when (it) {
-                    '`' -> "\\`"
-                    '\\' -> "\\\\"
-                    '$' -> "\\$"
-                    else -> it
-                }
-                stringBuilder.append(char)
-            }
-
-            stringBuilder.append("`")
-
-            return stringBuilder.toString()
         }
 
         @OptIn(ExperimentalStdlibApi::class)

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsExecutableMethod.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsExecutableMethod.kt
@@ -51,7 +51,7 @@ class JsExecutableMethod(
         private fun encodeArgsForJs(value: Any?): String {
             return when (value) {
                 null -> "null"
-                is String -> "'${looselyEscapeStringForJs(value)}'"
+                is String -> looselyEscapeAsStringLiteralForJs(value)
                 is Boolean, is Number -> value.toString()
                 is JsColor -> "'${colorToRgbHex(value.color)}'"
                 else -> throw NotImplementedError("Encoding ${value::class} for JS is not yet implemented")
@@ -59,19 +59,20 @@ class JsExecutableMethod(
         }
 
         // TODO: This method might not be enough to escape user inputs and prevent access to JS code execution
-        private fun looselyEscapeStringForJs(string: String): String {
-            val stringBuilder = StringBuilder()
+        private fun looselyEscapeAsStringLiteralForJs(string: String): String {
+            val stringBuilder = StringBuilder("`")
 
             string.forEach {
                 val char = when (it) {
-                    '"' -> "\\\""
-                    '\'' -> "\\'"
-                    '\n' -> "\\n"
-                    '\r' -> "\\r"
+                    '`' -> "\\`"
+                    '\\' -> "\\\\"
+                    '$' -> "\\$"
                     else -> it
                 }
                 stringBuilder.append(char)
             }
+
+            stringBuilder.append("`")
 
             return stringBuilder.toString()
         }


### PR DESCRIPTION
Now escapes every place that inserts any kind of content inside the editor's html. By the way, the previous escape method was missing the `\` character.

This new method relies on strings literals instead because it feels like there's less characters to escape this way.

Depends on #31 