### PR TITLE
feat: Add executeJsMethodWhenEditorIsSetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ editor.apply {
 }
 ```
 
+### Execute JavaScript after all the editor and its scripts are set up
+
+You might want to define some custom scripts that exposes functions for you to call later on in your logic. If you need to make
+sure the script is loaded before calling its methods, use `executeJsMethodWhenEditorIsSetup()`
+
+```kt
+// When setting up the editor add a script that will be loaded inside the <head> 
+editor.addScript(
+  """
+  function setBackground(color) {
+      document.body.style['background'] = color
+  }
+  """.trimIndent()
+)
+```
+
+```kt
+// When you need to execute the method from the above script inside some logic or button click
+editor.executeJsMethodWhenEditorIsSetup(JsExecutableMethod("setBackground", "#00FFFF"))
+```
+
 ### Use a custom WebViewClient with the editor
 
 To safely use your own WebViewClient instance with the editor, you have to call the

--- a/rich-html-editor/metalavaApi/api.txt
+++ b/rich-html-editor/metalavaApi/api.txt
@@ -113,6 +113,7 @@ package com.infomaniak.lib.richhtmleditor {
     method public void addCss(String css, optional String? id);
     method public void addScript(String script, optional String? id);
     method public void createLink(String? displayText, String url);
+    method public suspend Object? executeJsMethodWhenEditorIsSetup(com.infomaniak.lib.richhtmleditor.executor.JsExecutableMethod jsExecutableMethod, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public void exportHtml(kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> resultCallback);
     method @InaccessibleFromKotlin public kotlinx.coroutines.flow.SharedFlow<com.infomaniak.lib.richhtmleditor.EditorStatuses> getEditorStatusesFlow();
     method public void indent();

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/RichHtmlEditorWebView.kt
@@ -48,6 +48,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
@@ -81,12 +83,27 @@ class RichHtmlEditorWebView @JvmOverloads constructor(
     private var keepKeyboardOpenedOnConfigurationChanged: Boolean = false
 
     private val documentInitializer = DocumentInitializer()
+
+    //region JsLifecycleAwareExecutor
     private val stateSubscriber = StateSubscriber(this)
     private val htmlSetter = HtmlSetter(this)
     private val spellCheckHtmlSetter = SpellCheckHtmlSetter(this)
     private val jsExecutor = JsExecutor(this)
     private val scriptCssInjector = ScriptCssInjector(this)
     private val keyboardOpener = KeyboardOpener(this)
+    //endregion
+
+    // Always list all JsLifecycleAwareExecutor so we can determine when everything is done loading
+    private val hasLoadedAllJsExecutors = combine(
+        stateSubscriber.isWaitingForDom,
+        htmlSetter.isWaitingForDom,
+        spellCheckHtmlSetter.isWaitingForDom,
+        jsExecutor.isWaitingForDom,
+        scriptCssInjector.isWaitingForDom,
+        keyboardOpener.isWaitingForDom,
+    ) { isWaitingForDomList ->
+        isWaitingForDomList.all { it.not() }
+    }
 
     private val jsBridgeJob = Job()
     private val jsBridge = JsBridge(
@@ -197,6 +214,22 @@ class RichHtmlEditorWebView @JvmOverloads constructor(
      */
     fun addScript(script: String, id: String? = null) {
         scriptCssInjector.executeWhenDomIsLoaded(CodeInjection(type = InjectionType.SCRIPT, code = script, id = id))
+    }
+
+    /**
+     * Executes a JavaScript method inside the editor webview.
+     *
+     * This method suspends until all editor setup scripts are executed. This is useful for when you want to call a method from a
+     * custom script, and you want to make sure the script is loaded before calling it.
+     *
+     * If [executeJsMethodWhenEditorIsSetup] is called when the editor is already setup, [jsExecutableMethod] will be executed immediately.
+     *
+     * Setting up the editor requires to load or execute multiple scripts. Some scripts are loaded by default by the editor for it
+     * to function correctly, while other scripts are loaded by the user in order to customize the behavior of the editor webview.
+     */
+    suspend fun executeJsMethodWhenEditorIsSetup(jsExecutableMethod: JsExecutableMethod) {
+        hasLoadedAllJsExecutors.first { it }
+        jsExecutor.executeImmediately(jsExecutableMethod)
     }
 
     /**

--- a/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsLifecycleAwareExecutor.kt
+++ b/rich-html-editor/src/main/java/com/infomaniak/lib/richhtmleditor/executor/JsLifecycleAwareExecutor.kt
@@ -16,10 +16,16 @@
  */
 package com.infomaniak.lib.richhtmleditor.executor
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
 internal abstract class JsLifecycleAwareExecutor<T> {
 
     private var hasDomLoaded = false
     private val objectsWaitingForDom = mutableListOf<T>()
+
+    private val _isWaitingForDom = MutableStateFlow(true)
+    val isWaitingForDom = _isWaitingForDom.asStateFlow()
 
     fun executeWhenDomIsLoaded(value: T): Unit = synchronized(lock = this) {
         if (hasDomLoaded) executeImmediately(value) else objectsWaitingForDom.add(value)
@@ -29,6 +35,7 @@ internal abstract class JsLifecycleAwareExecutor<T> {
         hasDomLoaded = true
         objectsWaitingForDom.forEach(::executeImmediately)
         objectsWaitingForDom.clear()
+        _isWaitingForDom.value = false
     }
 
     abstract fun executeImmediately(value: T)


### PR DESCRIPTION
Sometimes we add scripts inside the `<head>` of the WebView that exposes some functions and we need to be able to call them at a later time. When calling them we need to make sure the scripts have been correctly initialized otherwise the function won't be found inside the WebView.

The introduced executeJsMethodWhenEditorIsSetup will wait for every setup script to be initialized before executing the JsMethod